### PR TITLE
please please please?!?!?!

### DIFF
--- a/src/c/JpcapWriter.c
+++ b/src/c/JpcapWriter.c
@@ -44,8 +44,10 @@ JNIEXPORT void JNICALL
 Java_jpcap_JpcapWriter_close(JNIEnv *env,jobject obj){
 	if(pdt!=NULL){
 		pcap_dump_close(pdt);
-		free(pcdd);
-		pcdd=NULL;
+        // the captor must handle closing itself in order to correctly clean up
+        // the reserveID
+		//free(pcdd);
+		//pcdd=NULL;
 	}
 	pdt=NULL;
 }


### PR DESCRIPTION
writers cannot close captors, as there are status flags in the captor that need updating that writers do not have access to.
